### PR TITLE
Bisect's Jest hook will fail when package-specs.in-source equals true

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -1,5 +1,11 @@
 {
   "name": "bisect-starter-bsb-jest",
+  "package-specs": [
+    {
+      "module": "commonjs",
+      "in-source": true
+    }
+  ],
   "bs-dependencies": [
     "bisect_ppx"
   ],


### PR DESCRIPTION
Error message from `npm run coverage`:

```sh
> bisect-starter-bsb-jest@ coverage /Users/jihchi/Repos/bisect-starter-bsb-jest
> jest

 FAIL  __tests__/hello_test.js
  ● Test suite failed to run

    Cannot find module 'bisect_ppx/lib/js/src/runtime/bucklescript/runtime.js' from 'jest.js'

      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:299:11)

Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        0.99s
Ran all test suites.
```

`__tests__/hello_test.js`:

```js
// Generated by BUCKLESCRIPT, PLEASE EDIT WITH CARE
'use strict';

var Jest = require("@glennsl/bs-jest/src/jest.js");
var Hello = require("../hello.js");

Jest.describe("largerThan10", (function (param) {
        Jest.test("< 10", (function (param) {
                return Jest.Expect.toEqual("< 10", Jest.Expect.expect(Hello.largerThan10(9)));
              }));
        return Jest.test(">= 10", (function (param) {
                      return Jest.Expect.toEqual(">= 10", Jest.Expect.expect(Hello.largerThan10(10)));
                    }));
      }));

/*  Not a pure module */
```

`./hello.js`

```js
// Generated by BUCKLESCRIPT, PLEASE EDIT WITH CARE
'use strict';

var Curry = require("bs-platform/lib/js/curry.js");
var Runtime$Bisect = require("bisect_ppx/src/runtime/bucklescript/runtime.js");

var match = Runtime$Bisect.register_file(undefined, undefined, "/Users/jihchi/Repos/bisect-starter-bsb-jest/hello.re", 3, "\x84\x95\xa6\xbe\0\0\0\n\0\0\0\x04\0\0\0\r\0\0\0\r\xb0\xa0ZB\xa0gA\xa0\x7f@");

var cb = match[1];

var Bisect_visit______Users___jihchi___Repos___bisect___starter___bsb___jest___hello___re = {
  ___bisect_visit___: cb
};

function largerThan10(i) {
  Curry._1(cb, 2);
  if (i >= 10) {
    Curry._1(cb, 1);
    return ">= 10";
  } else {
    Curry._1(cb, 0);
    return "< 10";
  }
}

exports.Bisect_visit______Users___jihchi___Repos___bisect___starter___bsb___jest___hello___re = Bisect_visit______Users___jihchi___Repos___bisect___starter___bsb___jest___hello___re;
exports.largerThan10 = largerThan10;
/* match Not a pure module */
```